### PR TITLE
Add sales dashboard with monthly statistics

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,7 +15,10 @@ use loan::{
     get_transaction_details, update_loan,
 };
 use product::{add_product, delete_product, get_all_products, get_product, update_product};
-use sales::{delete_sale, get_monthly_sales, get_sales_history, get_sales_items, update_sale};
+use sales::{
+    delete_sale, get_monthly_sales, get_monthly_sales_stats, get_sales_history, get_sales_items,
+    update_sale,
+};
 use stock::{add_stock, edit_stock, get_in_stock_products, get_stock_lots, remove_stock};
 use summary::{get_stock_histogram, get_stock_overview};
 
@@ -51,6 +54,7 @@ pub fn run() {
             get_sales_history,
             get_sales_items,
             get_monthly_sales,
+            get_monthly_sales_stats,
             create_loan,
             delete_loan,
             update_loan,

--- a/src/panes/Dashboard/DashBoard.css
+++ b/src/panes/Dashboard/DashBoard.css
@@ -176,7 +176,7 @@
 .accent-sales-this .dash-bar { background: rgba(59,130,246,.9); }
 .value-sales-this { color: #2563eb; } /* blue */
 
-accent-sales-last { --accent: rgba(100, 59, 246, 1); }
+.accent-sales-last { --accent: rgba(100, 59, 246, 1); }
 .accent-sales-last .dash-bar { background: rgba(100, 59, 246, .9); }
 .value-sales-last { color: #4f46e5; } /* indigo */
 

--- a/src/panes/Dashboard/DashBoard.css
+++ b/src/panes/Dashboard/DashBoard.css
@@ -176,6 +176,10 @@
 .accent-sales-this .dash-bar { background: rgba(59,130,246,.9); }
 .value-sales-this { color: #2563eb; } /* blue */
 
+accent-sales-last { --accent: rgba(100, 59, 246, 1); }
+.accent-sales-last .dash-bar { background: rgba(100, 59, 246, .9); }
+.value-sales-last { color: #4f46e5; } /* indigo */
+
 /* Respect dark theme — keep readable but still tinted */
 @media (prefers-color-scheme: dark) {
   .value-sellable { color: #34d399; }   /* green-400 */

--- a/src/panes/Dashboard/DashBoard.css
+++ b/src/panes/Dashboard/DashBoard.css
@@ -172,6 +172,10 @@
 .accent-loan-neg .dash-bar { background: rgba(239,68,68,.9); }
 .value-loan-neg { color: #dc2626; } /* red */
 
+.accent-sales-this { --accent: rgba(59,130,246,1); }
+.accent-sales-this .dash-bar { background: rgba(59,130,246,.9); }
+.value-sales-this { color: #2563eb; } /* blue */
+
 /* Respect dark theme — keep readable but still tinted */
 @media (prefers-color-scheme: dark) {
   .value-sellable { color: #34d399; }   /* green-400 */

--- a/src/panes/Dashboard/DashboardPane.tsx
+++ b/src/panes/Dashboard/DashboardPane.tsx
@@ -9,7 +9,7 @@ import "./DashBoard.css";
 import type { Card } from "../../types/Card";
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { DashboardData } from "../../types/dashboard";
+import { DashboardValueData } from "../../types/dashboard";
 
 type Props = {
   currency?: string;
@@ -31,25 +31,25 @@ export default function DashboardPane({
   onRefresh,
   refreshSignal,
 }: Props) {
-  const [data, setData] = useState<DashboardData | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [valueData, setValueData] = useState<DashboardValueData | null>(null);
+  const [valueLoading, setValueLoading] = useState(false);
+  const [valueError, setValueError] = useState<string | null>(null);
 
   const [salesStats, setSalesStats] = useState<{ this_month_total: number; last_month_same_period_total: number } | null>(null);
   const [salesStatsLoading, setSalesStatsLoading] = useState(false);
   const [salesStatsError, setSalesStatsError] = useState<string | null>(null);
 
   const fetchDashboardData = async () => {
-    setLoading(true);
-    setError(null);
+    setValueLoading(true);
+    setValueError(null);
     try {
-      const result = await invoke<DashboardData>("get_dashboard_summary");
-      setData(result);
+      const result = await invoke<DashboardValueData>("get_dashboard_summary");
+      setValueData(result);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "未能获取总览数据");
+      setValueError(err instanceof Error ? err.message : "未能获取总览数据");
       console.error("Error fetching dashboard:", err);
     } finally {
-      setLoading(false);
+      setValueLoading(false);
     }
   };
 
@@ -78,9 +78,9 @@ export default function DashboardPane({
   };
 
   // decide loan color by sign (asset vs liability)
-  const loanPositive = (data?.netLoanValue ?? 0) >= 0;
+  const loanPositive = (valueData?.netLoanValue ?? 0) >= 0;
 
-  if (error) {
+  if (valueError) {
     return (
       <div className="dash-wrap">
         <div className="dash-header">
@@ -91,17 +91,17 @@ export default function DashboardPane({
           </button>
         </div>
         <div style={{ padding: "2rem", textAlign: "center", color: "#666" }}>
-          <p>加载失败: {error}</p>
+          <p>加载失败: {valueError}</p>
         </div>
       </div>
     );
   }
 
-  const cards: Card[] = [
+  const valueCards: Card[] = [
     {
       key: "sellable",
       title: "可售总价值",
-      value: data?.totalSellableValue,
+      value: valueData?.totalSellableValue,
       icon: <DollarSign size={50} strokeWidth={2.4} />,
       accentClass: "accent-sellable",
       valueClass: "value-sellable",
@@ -116,7 +116,7 @@ export default function DashboardPane({
     {
       key: "soon",
       title: "即将过期价值",
-      value: data?.expiringSoonValue,
+      value: valueData?.expiringSoonValue,
       icon: <Clock8 size={50} strokeWidth={2.4} />,
       accentClass: "accent-soon",
       valueClass: "value-soon",
@@ -124,7 +124,7 @@ export default function DashboardPane({
     {
       key: "expired",
       title: "已过期价值",
-      value: data?.expiredValue,
+      value: valueData?.expiredValue,
       icon: <AlertTriangle size={50} strokeWidth={2.4} />,
       accentClass: "accent-expired",
       valueClass: "value-expired",
@@ -132,7 +132,7 @@ export default function DashboardPane({
     {
       key: "loan",
       title: "借/还净值",
-      value: data?.netLoanValue,
+      value: valueData?.netLoanValue,
       icon: <ArrowLeftRight size={50} strokeWidth={2.4} />,
       accentClass: loanPositive ? "accent-loan-pos" : "accent-loan-neg",
       valueClass: loanPositive ? "value-loan-pos" : "value-loan-neg",
@@ -171,7 +171,7 @@ export default function DashboardPane({
       </div>
 
       <div className="dash-grid-2x2">
-        {cards.map((c) => (
+        {valueCards.map((c) => (
           <div key={c.key} className={`dash-card ${c.accentClass}`}>
             {/* LEFT ICON + PATTERN */}
             <div className="dash-icon-left">
@@ -193,7 +193,7 @@ export default function DashboardPane({
               {"chips" in c && c.chips}
 
               <div className={`dash-value ${c.valueClass}`}>
-                {loading ? (
+                {valueLoading ? (
                   <span className="dash-skeleton" />
                 ) : (
                   formatCurrency(c.value, currency)

--- a/src/panes/Dashboard/DashboardPane.tsx
+++ b/src/panes/Dashboard/DashboardPane.tsx
@@ -211,28 +211,30 @@ export default function DashboardPane({
         <h2>销售总览</h2>
       </div>
 
-      {salesCards.map((c) => (
-        <div key={c.key} className={`dash-card ${c.accentClass}`}>
-          <div className="dash-icon-left">
-            <div className="dash-icon">{c.icon}</div>
-          </div>
-          <div className="dash-right">
-            <div className="dash-top">
-              <div className="dash-title-row">
-                <div className="dash-title">{c.title}</div>
+      <div className="dash-grid-2x2">
+        {salesCards.map((c) => (
+          <div key={c.key} className={`dash-card ${c.accentClass}`}>
+            <div className="dash-icon-left">
+              <div className="dash-icon">{c.icon}</div>
+            </div>
+            <div className="dash-right">
+              <div className="dash-top">
+                <div className="dash-title-row">
+                  <div className="dash-title">{c.title}</div>
+                </div>
+              </div>
+              <div className={`dash-value ${c.valueClass}`}>
+                {salesStatsLoading ? (
+                  <span className="dash-skeleton" />
+                ) : (
+                  formatCurrency(c.value, currency)
+                )}
               </div>
             </div>
-            <div className={`dash-value ${c.valueClass}`}>
-              {salesStatsLoading ? (
-                <span className="dash-skeleton" />
-              ) : (
-                formatCurrency(c.value, currency)
-              )}
-            </div>
+            <div className="dash-bar" />
           </div>
-          <div className="dash-bar" />
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/panes/Dashboard/DashboardPane.tsx
+++ b/src/panes/Dashboard/DashboardPane.tsx
@@ -9,7 +9,7 @@ import "./DashBoard.css";
 import type { Card } from "../../types/Card";
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { DashboardValueData } from "../../types/dashboard";
+import { DashboardValueData, DashboardSalesData } from "../../types/dashboard";
 
 type Props = {
   currency?: string;
@@ -35,7 +35,7 @@ export default function DashboardPane({
   const [valueLoading, setValueLoading] = useState(false);
   const [valueError, setValueError] = useState<string | null>(null);
 
-  const [salesStats, setSalesStats] = useState<{ this_month_total: number; last_month_same_period_total: number } | null>(null);
+  const [salesStats, setSalesStats] = useState<DashboardSalesData | null>(null);
   const [salesStatsLoading, setSalesStatsLoading] = useState(false);
   const [salesStatsError, setSalesStatsError] = useState<string | null>(null);
 

--- a/src/panes/Dashboard/DashboardPane.tsx
+++ b/src/panes/Dashboard/DashboardPane.tsx
@@ -46,7 +46,7 @@ export default function DashboardPane({
       const result = await invoke<DashboardValueData>("get_dashboard_summary");
       setValueData(result);
     } catch (err) {
-      setValueError(err instanceof Error ? err.message : "未能获取总览数据");
+      setValueError(err instanceof Error ? err.message : "价值总览获取失败");
       console.error("Error fetching dashboard:", err);
     } finally {
       setValueLoading(false);
@@ -79,23 +79,6 @@ export default function DashboardPane({
 
   // decide loan color by sign (asset vs liability)
   const loanPositive = (valueData?.netLoanValue ?? 0) >= 0;
-
-  if (valueError) {
-    return (
-      <div className="dash-wrap">
-        <div className="dash-header">
-          <h2>价值总览</h2>
-          <button className="dash-refresh" onClick={handleRefresh}>
-            <RefreshCw size={16} />
-            <span>重试</span>
-          </button>
-        </div>
-        <div style={{ padding: "2rem", textAlign: "center", color: "#666" }}>
-          <p>加载失败: {valueError}</p>
-        </div>
-      </div>
-    );
-  }
 
   const valueCards: Card[] = [
     {
@@ -195,6 +178,8 @@ export default function DashboardPane({
               <div className={`dash-value ${c.valueClass}`}>
                 {valueLoading ? (
                   <span className="dash-skeleton" />
+                ) : valueError ? (
+                  <span style={{ color: '#c00', fontSize: 14 }}>{valueError}</span>
                 ) : (
                   formatCurrency(c.value, currency)
                 )}
@@ -226,6 +211,8 @@ export default function DashboardPane({
               <div className={`dash-value ${c.valueClass}`}>
                 {salesStatsLoading ? (
                   <span className="dash-skeleton" />
+                ) : salesStatsError ? (
+                  <span style={{ color: '#c00', fontSize: 14 }}>{salesStatsError}</span>
                 ) : (
                   formatCurrency(c.value, currency)
                 )}

--- a/src/tabs.tsx
+++ b/src/tabs.tsx
@@ -31,7 +31,7 @@ export type TabKey =
 export const sidebarStructure: SidebarItem[] = [
   {
     key: "dashboard" as TabKey,
-    label: "价值总览",
+    label: "概况总览",
   },
   {
     key: "viewStock" as TabKey,

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -8,3 +8,10 @@ export interface DashboardValueData {
     /** 4) Net value of borrowed/lent products (positive = net asset, negative = net liability) */
     netLoanValue?: number;
 }
+
+export interface DashboardSalesData {
+    /** 1) Total monetary value sold for the month */
+    this_month_total: number;
+    /** 2) Total monetary value sold for the same period last month */
+    last_month_same_period_total: number
+}

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,4 +1,4 @@
-export interface DashboardData {
+export interface DashboardValueData {
     /** 1) Total sellable value = (total - expired); includes expiringSoon */
     totalSellableValue?: number;
     /** 2) Value of products which soon expire */


### PR DESCRIPTION
Enhance the dashboard by adding a backend and a usable front end, including a new layout and improved error display. Introduce monthly sales statistics with distinct color coding for current and previous months. Update variable names for clarity and implement a new data structure for sales data.